### PR TITLE
Pin dummy dependency to 1.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"version": "0.1.0",
 	"dependencies": {
 		"express": "^4.14.0",
-		"@freecodecamp/example": "~1.2.13"
+		"@freecodecamp/example": "^1.2.13"
 	},
 	"main": "server.js",
 	"scripts": {


### PR DESCRIPTION
- Using of ^ character to allow both minor and patches to be flexibly reflected in the dependency
- Use of ^1.2.13 translates to 1.x.x